### PR TITLE
Fix bug: RuntimeError: set_sizes_contiguous is not allowed on Tensor …

### DIFF
--- a/test_net.py
+++ b/test_net.py
@@ -272,11 +272,11 @@ if __name__ == '__main__':
     else:
       for i,index in enumerate(ratio_index_vu[0]):
         data = next(data_iter_vu)
-        im_data.data.resize_(data[0].size()).copy_(data[0])
-        query.data.resize_(data[1].size()).copy_(data[1])
-        im_info.data.resize_(data[2].size()).copy_(data[2])
-        gt_boxes.data.resize_(data[3].size()).copy_(data[3])
-        catgory.data.resize_(data[4].size()).copy_(data[4])
+        im_data.resize_(data[0].size()).copy_(data[0])
+        query.resize_(data[1].size()).copy_(data[1])
+        im_info.resize_(data[2].size()).copy_(data[2])
+        gt_boxes.resize_(data[3].size()).copy_(data[3])
+        catgory.resize_(data[4].size()).copy_(data[4])
 
 
         # Run Testing


### PR DESCRIPTION
When i tried your source with newer version of pytorch (1.4) the following error happened. 

```bash
Traceback (most recent call last):
  File "test_net.py", line 276, in <module>
    im_data.data.resize_(data[0].size()).copy_(data[0])
RuntimeError: set_sizes_contiguous is not allowed on a Tensor created from .data or .detach().
If your intent is to change the metadata of a Tensor (such as sizes / strides / storage / storage_offset)
without autograd tracking the change, remove the .data / .detach() call and wrap the change in a `with torch.no_grad():` block.
For example, change:
    x.data.set_(y)
to:
    with torch.no_grad():
        x.set_(y)

```
So i add a pr to fix it. 